### PR TITLE
Fix  cloud-set-guest-password download link

### DIFF
--- a/source/adminguide/templates/_password.rst
+++ b/source/adminguide/templates/_password.rst
@@ -46,10 +46,10 @@ Linux OS Installation
 
 Use the following steps to begin the Linux OS installation:
 
-#. Download the script file cloud-set-guest-password:
+#. Download the latest version of the cloud-set-guest-password script from the repository:
 
-   -  `http://download.cloud.com/templates/4.2/bindir/cloud-set-guest-password.in 
-      <http://download.cloud.com/templates/4.2/bindir/cloud-set-guest-password.in>`_
+   -  `https://github.com/apache/cloudstack/blob/master/setup/bindir/cloud-set-guest-password.in 
+      <https://github.com/apache/cloudstack/blob/master/setup/bindir/cloud-set-guest-password.in>`_
 
 #. Rename the file:
 


### PR DESCRIPTION
Download link for cloud-set-guest-password was pointing towards a non
existing page so I changed it to the github page of the script.